### PR TITLE
ci: switch swarm-upload to self-hosted runner

### DIFF
--- a/.github/workflows/swarm-upload.yaml
+++ b/.github/workflows/swarm-upload.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, bee]
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Switch the swarm-upload workflow to the org's self-hosted runners.

Trigger left unchanged — still `push` to main + manual dispatch.