### PR TITLE
ci(swarm-upload): set HUGO_CACHEDIR to runner temp

### DIFF
--- a/.github/workflows/swarm-upload.yaml
+++ b/.github/workflows/swarm-upload.yaml
@@ -21,7 +21,10 @@ jobs:
         with:
           hugo-version: '0.104.3'
       - name: Build
+        env:
+          HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
         run: |
+          mkdir -p "$HUGO_CACHEDIR"
           npm ci --prefix themes/swarm-blog
           npm run build --prefix themes/swarm-blog
           hugo -D --gc


### PR DESCRIPTION
Hugo defaults its cache dir to a system temp path that doesn't always exist on every runner. Pin it to the runner-provided temp directory so the Build step is portable across runner types.