### PR TITLE
docs: add Claude proofread skill and style guide

### DIFF
--- a/.claude/skills/proofread/SKILL.md
+++ b/.claude/skills/proofread/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: proofread
+description: Check text against Swarm voice and style guidelines, flag violations, and optionally apply fixes
+allowed-tools: Read, Edit, AskUserQuestion
+argument-hint: "[text-or-filepath]"
+---
+
+## Proofread
+
+**Trigger:** "Proofread: [text or file path]" or `/proofread [text-or-file]`
+
+**Purpose:** Check writing against Swarm's voice and style guidelines, return a corrected version with the changes called out, and optionally apply the fixes to the original file.
+
+**Config keys used:** None.
+
+---
+
+### Step 1 — Get the input
+
+From the argument:
+
+- **File path** — read the file. Note that it's a file (you'll be able to apply fixes in Step 5).
+- **Inline text** — work with the text directly. No file to write back to.
+
+If the input is unclear or missing, ask. Don't proceed without real content.
+
+### Step 2 — Read the style guideline
+
+Read `style/Swarm-identity-guideline.md`. It is the source of truth for voice, tone, and the non-negotiables — don't rely on a remembered list (per SKILL-STANDARD §1: discover, don't hardcode).
+
+### Step 3 — Check the text
+
+Run the text through every rule in the guideline. The current non-negotiables include — but always cross-check the file:
+
+- American English spelling
+- "Swarm Foundation" for org actions; "Swarm" for the network
+- No price or investment framing
+- No overpromises — future items are goals/plans, not guarantees
+- No contentious claims (e.g. "100% censorship-resistant")
+- Concise — every sentence adds value
+
+For each problem, capture: the exact phrase, which rule it violates, and the proposed fix.
+
+### Step 4 — Present the corrections
+
+Show the user:
+
+1. The **corrected version** — the full text with fixes applied in place.
+2. A **changelog** — bullet list, one entry per change: what changed and which rule.
+3. Any **violations you can't fix automatically** (e.g. a contentious claim that needs rewriting from scratch) — flag them with a recommendation, don't silently rewrite.
+
+Never fabricate corrections to make the text "punchier" — only flag real guideline violations.
+
+### Step 5 — Apply (optional)
+
+If the input was a file, ask the user (AskUserQuestion): apply the corrections to the file now, or leave it?
+
+- **Apply** — Edit the file with the corrected version.
+- **Leave** — just present the corrections; the user copies what they want.
+
+If the input was inline text, skip this step.
+
+### Step 6 — Verify
+
+If fixes were applied, re-read the file and check:
+
+- Every change in the changelog is present.
+- No new typos or wording introduced beyond the listed changes.
+
+Report: number of changes made, number of items flagged but not auto-fixed.
+
+If the text is already clean, say so plainly. A 0-changes report is a fine outcome.
+
+---
+
+### Notes
+
+- Proofread is a leaf — no handoff. The user decides what to do with the corrections.
+- Reference: `style/Swarm-identity-guideline.md`.

--- a/.claude/style/Swarm-identity-guideline.md
+++ b/.claude/style/Swarm-identity-guideline.md
@@ -1,0 +1,549 @@
+# The Identity Guide
+
+The purpose of this document is to provide guidelines for the consistent representation of both the Swarm Foundation and the Swarm network across all mediums.
+
+The first part, Core Elements, outlines the “big picture”: vision, mission, values, personality, and target audiences. These are tied to the Swarm Foundation. While the Foundation does not hold legal or administrative control over the network, it can – and should – set the ethical standards it upholds.
+
+The second part, Visual Identity, is based on the ‘product’, ie. the Swarm network itself. This section primarily serves as a practical guide for designers.
+
+The third and fourth parts, Communication Guidelines and Application Guidelines, aim to support the team in representing the Swarm network as Foundation members, and in shaping future marketing and PR campaigns that align with strategic goals and business development. The final section will be expanded once these plans are confirmed, complementing the foundational elements established in sections 1–3.
+
+All parts combined should result in consistent communication and design, helping to build a strong and recognizable identity.
+
+ 
+
+
+
+1. Core Elements 
+
+
+## **Vision**: A self-sovereign digital society.
+
+The vision of a *self-sovereign digital society* articulates a fundamental transformation in how to co-operate on the internet. It envisions a paradigm where individuals retain control over their data, identity, interactions, and economic activity online. This doesn’t mean attempting to replace corporations with code, but fostering a new digital commons where trust is embedded cryptographically rather than institutionally.
+
+This vision is rooted not in activism, but in architecture. The shift is technological: from client–server models to a peer-to-peer network, from ownership by platforms to ownership by participants. It's not just about decentralization for its own sake – it’s about aligning technological infrastructure with an idea of a society where participation is voluntary, transparent, and immune to unilateral censorship or surveillance.
+
+Swarm’s approach could be described as pragmatic optimism, anchored in protocol, not permission. It acknowledges the challenges, but insists that the way we cooperate over internet can be re-shaped through protocols that embed trust cryptographically, rather than institutionally.
+
+
+## **Mission**: Swarm as the back-end of web3
+
+How?
+
+
+
+1. By providing the necessary infrastructure to make that ‘self-sovereign digital society’ possible.
+2. By promoting and applying it in practice – ideally fostering a grassroots movement around it.
+
+Swarm’s mission is to provide the *infrastructure* for a new kind of internet network: one owned and operated by its users. This is a technical challenge and a cultural one. Swarm Foundation is primarily focusing on the technical side. That means creating resilient, scalable peer-to-peer systems that support everything from file storage to app hosting – without centralized control.
+
+But, as infrastructure alone could as well be a cry of a lonely man in the desert, Swarm Foundation’s mission also includes a cultural aspect – by encouraging good practice, experimentation, adoption, and education, so that Swarm doesn’t remain just a protocol, but becomes a living ecosystem. 
+
+The anchoring should be brave. We are the first step to everything on web3. All the ingredients, building blocks, are there for anything from chat to streaming, decentralised AI, proper support for data based services, all traditionally server-based scripts – are possible on a web3 level with Swarm. 
+
+
+### We do the network
+
+We provide the grounds. We do the hard work - the infrastructural layer that enables the web3, that empowers the cypherpunk vision. We show what *can be*, and invite the ecosystem to grow and develop solutions on top. 
+
+
+## **Values** 
+
+The Swarm *Foundation* values come from cypherpunk ethics, open-source philosophy, and digital humanism, but they remain grounded in practice:* \
+*
+
+**Inclusivity** - public and permissionless participation 
+
+**Integrity** - privacy, provable provenance 
+
+**Incentivisation** - alignment of interest of node and network 
+
+**Impartiality** - content and value neutrality 
+
+These metavalues can be thought of as systemic qualities which contribute to empowering individuals and collectives to gain self-sovereignty. Inclusivity means that we aspire to include the underprivileged in the data economy and lower the barrier of entry for defining complex data flows and building decentralised applications. Swarm is a network with open participation for providing services and permissionless access to publishing, sharing, and investing your data. While having the freedom to express their intentions as "actions" and retain full authority to decide if they want to remain anonymous or share their interactions and preferences, users must also uphold the integrity of their online persona. Economic incentives ensure that participants’ behaviour aligns with the desired emergent behaviour of the network. Impartiality guarantees the neutrality of content and prevents gatekeeping. It also reaffirms that the other three values are not only necessary but also sufficient: it eliminates any values that may treat any particular group as privileged or express a preference for specific content or data from a particular source.
+
+
+## **Personality**
+
+A 'swarm' is a set of individuals, in this case, a set of individuals forming and interacting in a p2p network. No one person, no one personality. A plural monolith.
+
+The Swarm *Foundation*, as steward of the vision, can however project a so-called personality: reflective, critical, idealistic, yet grounded in action.
+
+This "persona" is intellectually curious, slightly philosophically inclined but also practical and solutions oriented. It understands history – not only of technology, but of power. It’s aware that decentralization is not a cure-all and that any system, however well intended, can develop new hierarchies. That awareness breeds humility, but also clarity.
+
+Yet this persona is not cynical nor dry. It has a sense of humor, sees the paradoxes and absurdities, all the while remaining hopeful. It knows the status quo is unsustainable and that alternatives must be built, not just imagined. It believes that networks can carry values, and that infrastructure can be ideology made executable.
+
+It is both an engineer and a dreamer. It reads manifestos and merges pull requests. It’s not “political activism with code” — it’s engineering with values.
+
+ 
+
+
+## **Target Audience **
+
+Swarm is meant to serve anyone and everyone on a long run, but in this stage, the audience should be  primarily:
+
+
+
+* developers –specifically those among them who are either are web3 affirmative or/and are aligned with the core values of the Swarm (to contribute to development and drive adoption);
+* Value-aligned businesses, organizations that could/should implement Swarm in their products/solutions (to provide the use cases, drive adoption);
+* (online) privacy-focused activists, journalists (to spread the word);
+* web3 affirmative creatives and creative communities (to spread the word and improve our image).
+
+ 
+
+
+
+2. Visual Identity
+
+
+## **Logo, Color palette, Typography**
+
+
+
+* Logo Usage – Guidelines for logo placement, sizing, spacing, and variations
+* Color Palette – The brand’s official colors, including primary, secondary, and accent colors with HEX, RGB, and CMYK codes.
+* Typography – Fonts used for headings, body text, and accents, along with acceptable alternatives.
+
+[This folder](https://drive.google.com/drive/folders/1y4O8-4jKBvT-kkJ2o7com0oCpfp-kuGL) contains existing referential material on logo, spacing, typography and color palette. 
+
+*Comment: *The monochrome, 3d and geometrical logo as (re)designed by David are satisfactory (for now & given time and budgetary restraints), no need to redo these basics, basic color palette as established [by Egor](https://drive.google.com/drive/search?q=swarm%20identity) is ok for the time being.
+
+Typography should be reconsidered in parts - to catch up with 2025 (or, better put, to shake the 2020s vibe - ‘Space Mono’ is out of date), as well as the secondary color palette, to enable more flexibility and subtler designs. But it is not urgent at this point. We can play with what we have for the time being. Restrictions drive creativity. 
+
+ 
+
+Typography suggestions for consideration in the future: IBM Plex Mono, JetBrains Mono, Source Sans 3.
+
+
+## **Imagery & Graphics**
+
+Swarm’s visuals should look like its network: self-organizing, critical, humorous, never pretentious.
+
+It’s okay if it – actually, it *should* – feel at least a bit underground; that’s where revolutions incubate.
+
+When in doubt: strip away what’s decorative, keep what’s meaningful, and perhaps add one deliberate imperfection.
+
+Swarm’s visual identity should reflect what the network *is*: a living, decentralized organism of cooperation. \
+It’s not a product; it’s an ecosystem. Not a brand shouting from the center, but a pulse moving through many nodes. \
+Our visuals should express this balance: structure and entropy, precision and play, the logic of code and the chaos of life. Show what decentralization *feels* like. 
+
+Every visual element should point back to the deeper idea: a self-sovereign digital society built on voluntary connection, not control. While we are serious about the open internet, we don’t preach. We provoke, subvert, and make people look/think twice. \
+The aesthetic tone is flirting with glossy futurism, and subverting nostalgic retro into slightly distorted realism of the digital. Design like an art collective that understands networks, not like a corporation that sells them. 
+
+
+#### **Core Visual Principles**
+
+**a. Minimal, but alive - not sterile **
+
+
+
+* Use negative space as a tool – silence between signals.
+* Let geometrical forms breathe. Lines, grids, and nodes can carry rhythm, not just structure.
+* Simplicity with tension: a touch of distortion, a glitch, a broken symmetry keeps the design human and alive. \
+
+
+**b. Abstract, not figurative**
+
+
+
+* Avoid human faces, icons, or stock “tech” imagery.
+* Instead, evoke systems – flows, interactions, dependencies, emergence. \
+Think in patterns and processes, not pictures. The viewer should sense intelligence without seeing it directly. \
+
+
+**c. Punk in attitude, not on the surface**
+
+
+
+* Clean, but with an attitude.
+* A translation of what an older, dignified, wise, humorous person with plenty of joie de vivre (left) that was once a rebel, had angst, and all cynicism aside never quit on the idealistic youth ideals, would look like. Not vice versa. Punk in attitude, not on the surface. No “gen-whatever” style appropriations, make fun of everything (incl. yourself). 
+* Serious content, playful execution. A well-placed visual pun is welcome.
+* Allow the content to shine whenever possible. Support, complement, not overtake. 
+
+**d. Metaphor as method**
+
+
+
+* Translate Swarm concepts into visual metaphors (ex. “Backbone of Web3” → lattice or vertebral patterns. “Resilience” → fragmentation that still holds form). 
+* Let visuals *think*. If a poster or social tile looks like it might have an opinion, you’re on the right track.
+
+**e. Timeless**
+
+
+
+* Restrained color palette: black, white, grays, one or two bold accents (amber, signal yellow, or electric blue).
+* Type should be clear, slightly industrial – typography as infrastructure, not branding. \
+
+
+
+#### **Moodboard Words**
+
+Post-cypherpunk minimalism. \
+Digital brutalism. \
+Industrial poetry.
+
+Entropy with intention. \
+Code as calligraphy.
+
+Post-cypherpunk or post-cyberpunk anarcho-minimalism meets brutalism and industrial meets hi-tech psychedelic. \
+
+
+General guide for <span style="text-decoration:underline;">photography (at events)</span>:
+
+
+
+* candid (informal, relaxed, non staged) shots of developers collaborating, coding, or presenting Swarm at events;
+* always mind the privacy respecting angle, meaning no photos of people (recognisable) without their permission;
+* abstract representations of technology, such as interconnected circuits etc.
+
+     
+
+3. Communication Guidelines
+
+
+## **Core Principles**
+
+
+### Voice and tone
+
+Our communications should be based on the persona, established in the Core Elements section. 
+
+
+#### Voice
+
+
+
+* Intellectually Curious: We approach subjects with depth and nuance, drawing from history, philosophy, and technology. Our voice signals that we’ve done the reading, and the building. \
+
+* Grounded in Reality: We don’t overpromise. We acknowledge complexity, limitations, and trade-offs while staying solution-oriented. \
+
+* Idealistic but Practical: We balance visionary thinking with an engineer’s pragmatism. Big ideas always connect back to executable actions. \
+
+* Hopeful, Human, Humorous: We resist cynicism. Even when critical, our voice carries a constructive, forward-looking optimism. Do allow room for wit and lightness — a reminder that serious ideas don’t have to be expressed in boring or dry ways. A well-placed poke or bit of humor can make you more approachable and fun, which is what a community is primarily built around. 
+
+
+#### Tone
+
+Our tone flexes by context, but the following principles guide its expression:
+
+
+
+* Reflective, not preachy: We explain and explore, inviting readers to think with us rather than lecturing them. Avoid overly activist and righteous tone. \
+
+* Humble, not self-effacing: We recognize limits without diminishing the value of our work. \
+
+* Witty, not flippant: We allow space for humor and irony, acknowledging paradoxes without undermining seriousness. \
+
+* Precise, not dry: We use clear, well-chosen words: technical where necessary, plainspoken where possible. \
+
+* Critical, not cynical: We identify problems honestly, but always pivot toward constructive alternatives. \
+
+
+
+### Key general messaging pillars
+
+
+#### What Swarm is (at a glance)
+
+
+#### ** \
+**Swarm is a foundational, horizontal layer for Web3—a content-addressed, peer-to-peer network for user-owned storage and data transport. It supports a wide range of use cases, including hosting dApp frontends and docs, serving media and livestreams, powering chat and messaging, backing up datasets, delivering creator content, and serving as a storage and verification layer in the agentic economy. 
+
+In short, Swarm is a full-stack data substrate that lets builders ship familiar experiences without relying on central servers.
+
+The Swarm network is permissionless. Anyone can join—no approvals or central accounts required. Data is located by its hash rather than a server, can be encrypted client-side so only key holders can read it, and is retrieved peer-to-peer instead of through a trusted intermediary. 
+
+Gateways and multichain apps can be used as optional on-ramps (avoiding running your own node to access the network) – control remains with users, preserving private control and open access.
+
+
+#### 1. Decentralization as Infrastructure
+
+Swarm is a peer to peer network. Not an app, not a platform. It’s the foundational layer for Web3. Like a global hard drive, it enables data to live beyond borders, companies, or governments. It’s the infrastructure.
+
+*Message Focus*: Swarm provides the backbone on which future apps can be built.
+
+
+#### 2. Data Sovereignty & User Control
+
+In Swarm, data belongs to its creator. There are no intermediaries, no hidden hands, no single chokepoint of control. Immutability and encryption ensure integrity and privacy, while permissionless access gives users choice over what to share and what to keep private.
+
+*Message Focus*: Swarm puts data back in the hands of the people who create it.
+
+
+#### 3. Resilience & Permanence
+
+Swarm is designed for durability: data is split, distributed, and replicated across a global network of independent nodes. This architecture foresees robustness against censorship, downtime, and manipulation.
+
+At the same time, it’s important to be clear: because the network is not owned or controlled by the Swarm Foundation (or any single entity), no absolute guarantees on data availability can be made. What we can say is that the system’s very design incentivizes persistence: the more participants, the stronger and more resilient the network becomes.
+
+*Message Focus*: Swarm offers resilience by design, not by promise – a network that strengthens through collective participation.
+
+
+#### 4. Beyond Storage: A Living Web
+
+Swarm isn’t just decentralised storage. It enables traceless communication, dynamic websites, personal blogs, dApps, and platforms that update without heavy re-uploads. It makes the web alive, mutable at the edges while preserving integrity at the core.
+
+*Message Focus*: Swarm is not only storage – it’s a wholesome infrastructure.
+
+
+#### 5. Incentives & Sustainability
+
+Swarm is powered by economic mechanisms that reward participation. Nodes earn for contributing storage and bandwidth, aligning individual incentives with the health of the network. This creates a self-sustaining system that can scale globally without central gatekeepers.
+
+*Message Focus*: Swarm is designed to grow stronger the more people use it – a living ecosystem, not a walled garden.
+
+
+#### 6. Pragmatic Idealism
+
+Swarm is aware that decentralization is not a silver bullet. Any system can produce hierarchies. But instead of shying away from complexity, Swarm embraces it by designing infrastructure that is open, adaptive, and evolving. With clarity and humility we build what the status quo cannot sustain.
+
+*Message Focus*: Swarm balances vision with execution – we are following the cypherpunk narrative: write code.
+
+
+## Writing Style & Language 
+
+
+### Grammar preferences, punctuation, capitalization rules, etc.	
+
+
+### Naming convention 
+
+
+### Always use appropriate legal entity name instead of just Swarm:
+
+
+
+* Right: “Swarm Foundation is announcing…”
+* Wrong: “Swarm is announcing”
+* Wrong: Using “we” to refer to Swarm network; we should only refer to Swarm Foundation, and not the software and efforts deployed on the software since multiple efforts by multiple independent groups are deployed. SF does not represent the whole of the Swarm network (and vice versa).
+
+‘Swarm’ is referring to the network; after establishing that, the ‘network’ part can be omitted (keeping only ‘Swarm’ to refer to the network).
+
+
+### Grammar
+
+American English. **NB: it used to be British English, but as it has been observed, British is not EU anymore and most of the academic papers are now written in American English. Hence the change. Viktor Tron’s own papers can remain British English as a personal OG choice.**
+
+When naming products, releases, libraries etc. - make sure you follow the established naming to avoid inconsistencies (ex. Bee-js vs. BeeJS vs. Bee-JS). 
+
+
+### Preferred Vocabulary 
+
+Use positive examples instead of negative where possible
+
+
+
+* Right: “We are empowering digital freedom”
+* Wrong: “We are bringing down Facebook/AWS or whatnot”
+
+Announcements about products, releases and deliverables should reflect the actual state of matters.
+
+Announcements about future partnerships, collaborations and ideas, including roadmap, should be communicated clearly as goals and not facts. They can and should be inspirational, but not based on promises. Avoid “overselling” and overstating, but also avoid using negatively charged words when describing the state of the network and any occurrences. 
+
+Avoid political comments or singling out specific groups, nations, or religions.
+
+Avoid phrases that can become basis for legal obligations or have a legal meaning, e.g. “joint-venture”. 
+
+Avoid exaggerations that may be relied upon by others in good faith and avoid communicating on contentious matters or things that may be considered contentious by part of the community before we come up with an org-wide strategy. Bring it to the attention of the Council /COO / track leads.
+
+Do not make bold statements that may be incorrect. (current ex. The Swarm network is 100% censorship resistant.)
+
+Use legal entity name, not “we”
+
+
+
+* Right: “Swarm Foundation released a new version of Bee client”
+* Right: “A new version of Bee client has been released.”
+* Wrong: “We released a new version of Bee client”
+* Wrong: “Swarm released a new version of Bee client”
+
+Less is more. Keep sentences short, no superfluous descriptions. Every word, every sentence should add value. 
+
+Don’t:
+
+
+
+*  include references to the expectation of a reward or other monetary gain
+* discuss token price, nor present the project as an investment opportunity or recommendation thereof
+* present your statements on social media as a statement on behalf of Swarm Foundation or its affiliated entities or projects
+
+Do: 
+
+
+
+* include “views are my own” when posting personal opinions on anything in relation with the Swarm network or Swarm Foundation in private accounts in social media 
+
+
+## **Content**
+
+ When writing content, we should not lean into activism, ideological positioning, and political tone (with notable exceptions). That risks overshadowing the **main strength**: Swarm as a <span style="text-decoration:underline;">technical project delivering concrete infrastructure and solutions</span>. The **“cypherpunk / ideological” layer** should remain as a ***narrative frame* or background inspiration**, but the **core narrative should stay anchored in technology, pragmatism, and solutions. **Therefore:
+
+
+
+* Non-technical team members should be equipped to explain Swarm at a high level, starting with its mission, vision, roots, to basics of how the Swarm »works«, while developers should possess a deeper knowledge of Swarm’s technical aspects, also in relation to the general mission and vision, as well as basic knowledge of the web3 space, its roots and ideals. When speaking about the Swarm network (and the Foundation, for that matter) - *be honest, but protective*. *
+
+    *	*Fictional example: 15k nodes go offline overnight, leaving only 9k in the network. Sounds bad. Is bad. How to report on it / respond in public?*
+
+
+     Honest but protective attitude:* While this is a notable contraction, it also presents a critical stress test for the system’s ability to self-correct and adapt.*
+
+
+    *Because the network is built on storage incentives, this event provides valuable insights into participant behavior, economic dynamics, and infrastructure resilience. It allows us to identify whether incentive mechanisms are correctly aligned or if adjustments are needed to ensure long-term sustainability.*
+
+
+    *Importantly, the remaining nodes continue to function, demonstrating the core strength of decentralization... The fact that the network remains online and data available despite this scale of reduction is a testament to its robustness.*
+
+* All non-technical (high-level) and technical team members (deep knowledge) should be able to explain Swarm, covering the following points:
+* Swarm's history and origins.
+* Mission and vision.
+* What Swarm is and how it works.*
+* Key (differentiating) features of Swarm.*[^1]
+
+
+* Demonstrate the Swarm desktop app and its features.
+
+When preparing for speeches, be aware of and adapt to the following:
+
+
+
+* Who is your target audience
+* What is the context
+* What is the goal of your speech (is it to educate the audience, expose a problem, present or explain a particular technical solution, or is it foremost to inspire them to either join the Swarm community, approach you for partnerships, start building their own apps or whatnot on Swarm, spread the word about Swarm etc.)
+* What key messages do you want to convey
+* Refrain from expressing any personal political or ideological views.
+4. Application Guidelines
+
+
+## Taglines & Slogans 
+
+*These are to be considered for various stickers and swag campaigns in general. *
+
+We do the network. (you do the networking)
+
+swarm – head in the un-cloud
+
+Together we are Swarm.
+
+Bee the change.
+
+Form - reform - uniform - Swarm
+
+Upload and disappear. 
+
+Let the network hodl. 
+
+Cache me if you can. 
+
+(Push here to) Reset the web.
+
+When we are millions, we will be one.  
+
+/bee is not your personal army
+
+We are from the future. 
+
+We are all individuals
+
+Plural monolith
+
+Ceci n’est pas cypherpunk (with logo)
+
+Trust is good, control is better.
+
+…
+
+
+## Business & Marketing Materials
+
+Swarm Foundation’s business and marketing materials must embody clarity, credibility, and recognizability. Whether it’s a one-page handout, a detailed whitepaper, or a partner presentation, the materials serve as an extension of the protocol’s ethos: minimal, precise, and resilient.
+
+
+#### General principles:
+
+
+
+* **Consistency first.** Logo placement, typography, and color palette must follow the Visual Identity guidelines. Never distort or crowd the logo. Allow adequate space around it. \
+
+* **Minimal and bold.** Avoid cluttered layouts. Every element should serve a function: to communicate clearly, not decorate. \
+
+* **Anchor in function.** Illustrations and graphics should reflect Swarm metaphors (e.g., backbone, networks, distributed patterns), not generic tech stock visuals. \
+
+* **Tone of content.** Materials should be precise, pragmatic, and anchored in technical credibility (not marketing hype). \
+
+
+
+#### Specific use cases:
+
+
+
+* **Brochures & Flyers:** Use for high-level introductions. Key messages should align with the six general messaging pillars (Decentralization as Infrastructure, Data Sovereignty, etc.). Keep text concise, supported by strong metaphors and visual abstractions. \
+
+* **Business PDFs & Whitepapers:** Use a structured, modular layout with clear sectioning. Typography should prioritize readability; longer documents should use body fonts optimized for screen and print. \
+
+* **Presentations & Slides:** Use a restrained color palette with bold contrasts for emphasis. Favor abstract diagrams, protocol schematics, or CLI screenshots over stock photography. Limit text per slide — the speaker should do the explaining.
+
+
+## Social Media Guidelines
+
+Social platforms are the most dynamic layer of Swarm’s communications. They must project consistency without falling into corporate sterility.
+
+
+#### Profile & Branding:
+
+
+
+* Always use the official Swarm Foundation logo for organizational accounts. \
+
+* Keep profile and header images abstract and aligned with the visual identity (no stock or figurative imagery). \
+
+* Do not modify the logo with seasonal or topical overlays unless explicitly approved. \
+
+
+
+#### Post Style:
+
+
+
+* **Tone:** Humorous when appropriate, reflective when necessary, always constructive and anchored in Swarm’s persona (curious, idealistic yet grounded). \
+
+* **Language:** Short, precise, and direct. Use technical clarity and emphasise the ‘why’ or ‘how’ angle - bringing out the value proposition. \
+
+* **Visuals:** Prefer clean graphics, CLI screenshots, or abstract designs from the established style guide. Meme templates could occasionally be used for added attention and “wits”, but stock photos or trending AI art filters should be avoided. \
+
+* **Format:** Use consistent templates for announcements (new release, events, partnerships). Keep community updates visually distinct from technical releases. \
+
+
+
+#### Engagement:
+
+
+
+* Foster conversation. Use open questions, polls, and calls for feedback when appropriate. \
+
+* Respect privacy: do not repost identifiable images without consent. \
+
+* Do not engage in political or ideological disputes under organizational accounts. \
+
+* Individuals (working for Swarm Foundation) should be encouraged to post and engage on topics related to SF development and core ide(al)s, establishing an image of a strong, synced and active team. \
+
+
+
+### Website & Digital Presence - TBA
+
+
+#### Design principles for web pages and app interfaces. 
+
+
+<!-- Footnotes themselves at the bottom. -->
+## Notes
+
+[^1]:
+
+     * For the ‘what’ part - here are Viktor’s thoughts on the matter (as best as I could type what he was saying at a meeting in November 2024): Follow the cypherpunk narrative. We may be the most underground, unknown, but yet we are the most multi-providing, it’s the *whole(some) infrastructure* that we provide. Also, we must not forget that we are a part of the cypherpunk ethereum narrative. The web3 is the decentralised web. The web that is eliminating data silos, tracking, random security problems, defacing, ddos attacks; this is web3. We simply have to name the game. We are providing the next big step of the evolution. Communication protocols, the whole infrastructure, not just storage. Let’s contextualise us as the ones providing the final solution for the idea of the proper web3 as envisioned at Devcon 0. Now it’s possible, in 2014 it was only conceptualised. The services as uber, airbnb, reddit etc - that can now be done in a peer to peer manner. Now, we can say we are the back-end of web3. Content wise: the anchoring should be brave. Not like file storage for dapps, not like storage for blobs. We are the next step to everything on web3. All the ingredients are there for chat, communications, subscriptions, streaming, proper support for data base services, all traditionally server based scripts - are possible on a web3 level now with Swarm. 
+    RE: decentralised storage
+    Swarm is more than ‘just decentralised storage’ - the whole network is the storage. This is not like in IPFS. Swarm is not a file sharing system. You don’t need to be a seeder to keep your content up and access the other. Swarm has seamless retrieval right away. bittorrent and ifps - not possible, not very efficient to retrieve if you leave the server. 
+RE: bandwidth incentives 
+    There’s often a hidden or overlooked service you’re paying (elsewhere) - to retrieve, call for content. In swarm: if you can appreciate that you can offload retrieval costs to the user, it can be done. Example: dapps - could work with subscription models. Monetization for the bandwidth of public data is provided for - this is otherwise hidden in the storage costs, with swarm, it’s separated and offloaded to users, we have served assets, not inner assets. For gaming, real time streaming - we are unique in offering that. Not only are we fast enough to do it, we are also providing a monetization system to cover the bandwidth issue. provides a smoother way for start ups. Tech and monetization problems related to bandwidth and retrieval are taken care of. the most important difference to any other “competitors”. 
+    RE: Privacy 
+    You don’t reveal who uploaded the content, it’s anonymous. Also, if you want to conceal the file - it’s shredded, it can get dark, and you are not exposed. Also, you cannot target content retrieval. 
+    >> privacy properties, bandwidth problems solved, and upload and disappear - the three properties that are KEY.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+# What does this PR resolve? 🚀
+
+<!-- One-line summary. Then bullets: the key changes and, briefly, the why. -->
+
+# Details 📝
+
+<!-- Implementation specifics, trade-offs, anything a reviewer needs.
+     For content posts (e.g. STON): note the blog/language, publish date, and draft state. -->
+
+# Checklist ✅
+
+- [ ] Merged the latest base branch and resolved conflicts
+- [ ] Site builds locally (`hugo -D --gc`) and looks right in `hugo server`
+- [ ] Recompiled theme CSS if templates/styles changed (`npm run build --prefix themes/swarm-blog`)
+- [ ] Kept frontmatter schema in sync across TinaCMS and Forestry if fields changed
+- [ ] Set the correct `date` and `draft` state on any new/edited posts
+- [ ] Self-reviewed the diff

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A Hugo static site for the Swarm blog, deployed to the Swarm decentralized network (not a normal web host). It uses Hugo's **multilanguage** feature as a trick to host **several independent blogs** in one site — each "language" is actually a separate blog.
+
+## Commands
+
+Run from repo root unless noted.
+
+```bash
+hugo server                 # local preview at http://localhost:1313/
+npm run dev                 # TinaCMS dev + hugo server (content editing UI)
+npm run forestry:preview    # hugo server with drafts/future/expired (-F -D -E -w)
+```
+
+CSS lives in the theme and must be compiled separately (Tailwind). Run inside `themes/swarm-blog/`:
+
+```bash
+npm install                 # also vendor-copies fuse.js into assets/lib
+npm run dev                 # watch + compile Tailwind -> assets/css/compiled/main.css
+npm run build               # production Tailwind build
+```
+
+Full production build (root) — this is what CI runs:
+
+```bash
+npm ci --prefix themes/swarm-blog
+npm run build --prefix themes/swarm-blog   # compile theme CSS first
+hugo -D --gc
+npx -y pagefind --site public              # build local search index
+```
+
+There is no test suite (`npm test` is a stub).
+
+## Deployment
+
+`.github/workflows/swarm-upload.yaml` runs on push to `main` (self-hosted `bee` runner). It builds the site, generates the Pagefind index, uploads `./public` to Swarm via `ethersphere/swarm-actions`, and writes a Swarm feed (`topic: swarm-blog`) so the blog resolves to a stable address. Output is **content-addressed on Swarm**, not a CDN — there is no rollback; a bad publish means another publish.
+
+## Content architecture
+
+Each language in `config.toml` is a **distinct blog** with its own `contentDir`:
+
+- `en` → `content/` (root) — Swarm News Blog
+- `foundation` → `content/foundation/` — Swarm Foundation Blog (the main, active blog)
+- `hive` → `content/hive/`
+- `wam` → `content/wam/` (We Are Millions)
+- `fds` → `content/fds/` (Fair Data Society)
+- `zh` → `content/zh/` (Chinese)
+
+Posts are flat Markdown files under `content/<blog>/posts/`. Each blog has an `_index.md`. Permalink scheme: `/:year/:slug/`.
+
+**Frontmatter is TOML, delimited by `+++`** (not YAML `---`). Common fields seen on posts: `title`, `date`, `description`, `categories`, `banner`, `images`, `references_and_footnotes`, `draft`, `_template`. New posts default to `draft: true` (see `archetypes/default.md`) — publishing means setting `draft = false`.
+
+Images go in `static/uploads/` and are referenced as `/uploads/<file>` (the `static/` prefix is dropped at build).
+
+### State of the Network (STON)
+
+A recurring monthly report series in `content/foundation/posts/swarm-state-of-the-network-<month>-<year>.md`, with chart images in `static/uploads/`. Recent git history is mostly STON publishing (setting publish dates, adding chart images, flipping `draft`). When asked to "publish STON," that means dropping in the post + chart images and setting the correct `date` / `draft = false`.
+
+## Content editing systems
+
+Content is edited through hosted CMS UIs, so two parallel config systems exist and both describe the post schema — keep them in sync if you change frontmatter fields:
+
+- **TinaCMS** — `tina/config.ts` + `tina/templates.ts`. `npm run dev` runs it. Uses `frontmatterFormat: "toml"`, `+++` delimiters. Builds admin UI to `static/admin`.
+- **Forestry** (legacy) — `.forestry/front_matter/templates/{post,home}.yml`.
+
+## Custom shortcodes
+
+Defined in `themes/swarm-blog/layouts/shortcodes/`. `markup.goldmark.renderer.unsafe = true` is enabled, so raw HTML in Markdown is allowed.
+
+```markdown
+{{< image src="/uploads/x.png" alt="Alt" caption="Caption" >}}
+
+{{< admonition note >}}      <!-- types: note tip info warning danger -->
+markdown content here
+{{< /admonition >}}
+```
+
+## Theme
+
+`themes/swarm-blog/` is a vendored Tailwind theme. Templates in `layouts/` (note `layouts/posts/single.html` for post rendering, `layouts/partials/articles/*` for listing cards). Search uses **Pagefind** (index built at deploy) styled to match the blog; `params.toml` toggles `enableSearch`. Prettier with `prettier-plugin-go-template` + `prettier-plugin-tailwindcss` formats templates.


### PR DESCRIPTION
# What does this PR resolve? 🚀

Adds Claude Code tooling to help author and review blog content in Swarm's voice.

- Adds a `/proofread` skill (`.claude/skills/proofread/SKILL.md`) that checks text against Swarm voice/style and optionally applies fixes
- Adds the Swarm identity & style guideline (`.claude/style/Swarm-identity-guideline.md`) the skill references
- Expands `CLAUDE.md` with repo guidance (architecture, build, content, deploy)

# Details 📝

- Tooling/docs only — no site content, templates, or theme changes; build output is unaffected.
- Two commits: the proofread skill + style guide, and this repo's new PR template.

# Checklist ✅

- [ ] Merged the latest base branch and resolved conflicts
- [ ] Site builds locally (`hugo -D --gc`) and looks right in `hugo server`
- [ ] Recompiled theme CSS if templates/styles changed (`npm run build --prefix themes/swarm-blog`)
- [ ] Kept frontmatter schema in sync across TinaCMS and Forestry if fields changed
- [ ] Set the correct `date` and `draft` state on any new/edited posts
- [x] Self-reviewed the diff
