### PR TITLE
Fix client-side stamping docs in Bee v2.8.1 release post

### DIFF
--- a/content/foundation/posts/bee-v2.8.1-release.md
+++ b/content/foundation/posts/bee-v2.8.1-release.md
@@ -74,7 +74,13 @@ Bee v2.8.1 lets a client sign its own postage stamps and upload already-stamped 
 Together with the AutoTLS and secure WebSocket (WSS) support from v2.7.0, this is another step toward running Bee directly in the browser.
 
 {{< admonition tip >}}
-**For developers:** this is a feature update to the existing `/chunks/stream` WebSocket endpoint. To upload pre-signed (stamped) chunks, set the `Swarm-Postage-Batch-Id` header on the `/chunks/stream` request. Browsers, which can't set custom headers on a WebSocket connection, can pass the `swarm-tag` query parameter instead.
+**For developers:** the **`/chunks/stream` (WebSocket)** endpoint accepts pre-signed (client-stamped) chunks.
+
+Omit the `Swarm-Postage-Batch-Id` header on the connection to enter per-chunk-stamp mode. 
+Then, for each chunk, send the stamp envelope bytes (113 bytes) first, followed by the chunk data (span + payload). 
+With the batch-id header set instead, each message is treated as raw chunk data.
+
+Browsers, which can't set custom headers on a WebSocket connection, can pass the `swarm-tag` query parameter instead.
 {{< /admonition >}}
 
 ## Dev Mode Has Been Removed

--- a/content/foundation/posts/bee-v2.8.1-release.md
+++ b/content/foundation/posts/bee-v2.8.1-release.md
@@ -14,8 +14,6 @@ aliases = [
 ]
 +++
 
-## Bee v2.8.1 Released
-
 *Bee v2.8.1 is a non-disruptive release focused on performance, data durability, and developer experience, with some operational cleanup. It is scheduled for release on **July 7th, 2026**.*
 
 ## What Is Changing


### PR DESCRIPTION
# What does this PR resolve? 🚀

Fixes two issues in the Bee v2.8.1 release post:

- Removed `## Bee v2.8.1 Released` heading to avoid release date confusion.
- Corrected the developer tip box under "Client-Side Stamping for Browser Uploads" section, which incorrectly told developers to set \`Swarm-Postage-Batch-Id\` to upload pre-signed chunks — that header is for server-side stamping, not client-side. The corrected tip now describes the actual binary framing protocol: omit the batch-id header to enter per-chunk-stamp mode, then send envelope bytes (113 bytes) first followed by chunk data (span + payload) for each chunk.

# Details 📝

The original tip conflated two distinct modes of the \`/chunks/stream\` endpoint:
- **Server-side stamping:** caller sets \`Swarm-Postage-Batch-Id\`; Bee stamps each chunk.
- **Client-side stamping (new in v2.8.1):** caller omits that header; each WebSocket message is a concatenation of the stamp envelope and chunk data, and Bee recognises the binary framing.

The corrected tip also retains the \`swarm-tag\` query parameter note, which was accurate — it's needed because browsers can't set custom headers on WebSocket connections.

# Checklist ✅

- [x] Merged the latest base branch and resolved conflicts
- [x] Site builds locally (\`hugo -D --gc\`) and looks right in \`hugo server\`
- [x] Recompiled theme CSS if templates/styles changed — N/A; content-only change, no template or CSS edits
- [x] Kept frontmatter schema in sync across TinaCMS and Forestry if fields changed — N/A; no frontmatter fields added or removed
- [x] Set the correct \`date\` and \`draft\` state on any new/edited posts
- [x] Self-reviewed the diff