### PR TITLE
Update Bee v2.8.1 release date related tone

### DIFF
--- a/content/foundation/posts/bee-v2.8.1-release.md
+++ b/content/foundation/posts/bee-v2.8.1-release.md
@@ -14,7 +14,7 @@ aliases = [
 ]
 +++
 
-*Bee v2.8.1 is a non-disruptive release focused on performance, data durability, and developer experience, with some operational cleanup. It is scheduled for release on **July 7th, 2026**.*
+*Bee v2.8.1 is a non-disruptive release focused on performance, data durability, and developer experience, with some operational cleanup. It was released on **July 7th, 2026**.*
 
 ## What Is Changing
 
@@ -112,7 +112,7 @@ Bee v2.8.1 fixes this: the node now signs its address record **once and reuses t
 The network's minimum supported version has been **v2.8.0** since the [v2.8.0 release](https://blog.ethswarm.org/foundation/2026/bee-2-8-release/#updated-p2p-protocol-compatibility), which introduced breaking p2p protocol changes. Bee v2.8.1 now removes the remaining v2.6.0 backward-compatibility code, so nodes still on v2.6.0 or earlier also lose the ability to upgrade directly to v2.8.1.
 
 {{< admonition warning >}}
-**If you are still running a Bee v2.6.0 (or older) node:** upgrade to **v2.8.0 now**, then to **v2.8.1** once it is released, or re-install the node fresh on **v2.8.1**.
+**If you are still running a Bee v2.6.0 (or older) node:** upgrade to **v2.8.0** first, then to **v2.8.1**, or re-install the node fresh on **v2.8.1**.
 {{< /admonition >}}
 
 ## API & Developer Changes
@@ -146,7 +146,7 @@ On the maintenance side: the Docker Compose environment variables were updated t
 
 ## Full Changelog
 
-For the complete list of changes, see the [Bee v2.8.1 release changelog](https://github.com/ethersphere/bee/releases/tag/v2.8.1) on GitHub (live on release day).
+For the complete list of changes, see the [Bee v2.8.1 release changelog](https://github.com/ethersphere/bee/releases/tag/v2.8.1) on GitHub.
 
 ## Need Help?
 
@@ -154,4 +154,4 @@ If you're a node operator or developer with questions about upgrading or the new
 
 ---
 
-*Bee v2.8.1 is scheduled for release on **July 7th, 2026**. This post will be updated when it goes live. Start planning your upgrade now, especially if you use dev mode for local development or still run a Bee v2.6.0 node.*
+*Bee v2.8.1 was released on **July 7th, 2026**. Plan your upgrade now, especially if you use dev mode for local development or still run a Bee v2.6.0 node.*


### PR DESCRIPTION
# What does this PR resolve? 🚀

Update the Bee v2.8.1 release post to a past-tense, "has been released" tone now that release day (7 July 2026) has arrived.

- Intro: "is scheduled for release on July 7th, 2026" → "was released on July 7th, 2026"
- v2.6.0 upgrade warning: dropped "once it is released"
- Changelog: dropped "(live on release day)"
- Closing note: de-futured to "was released on July 7th, 2026"

> ⚠️ **Do not merge yet.** This PR will be merged once the Bee v2.8.1 release is confirmed.

# Details 📝

- **Blog:** Swarm Foundation (`foundation`)
- **File:** `content/foundation/posts/bee-v2.8.1-release.md` (4 line changes)
- Prose-only tone shift; no frontmatter, date, or `draft` state changes

# Checklist ✅

- [x] Merged the latest base branch and resolved conflicts
- [x] Site builds locally (`hugo -D --gc`) and looks right in `hugo server`
- [x] Recompiled theme CSS if templates/styles changed — N/A, prose-only
- [x] Kept frontmatter schema in sync across TinaCMS and Forestry if fields changed — N/A, no frontmatter changed
- [x] Set the correct `date` and `draft` state on any new/edited posts — N/A, no date/draft change in this diff
- [x] Self-reviewed the diff
